### PR TITLE
Ubuntu 16.04 linux-tools package names fix

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -8,7 +8,10 @@ class hyperv::debian {
       # Are we running one of the virtual kernels?
       $virtual = $::kernelrelease ? {
         /virtual$/ => '-virtual',
-        default   => '',
+        default   => versioncmp($::operatingsystemrelease, '16.04') >= 0 ? {
+          true    => '-generic',
+          default => '',
+        },
       }
 
       # List of packages to install

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -6,12 +6,12 @@ class hyperv::debian {
     'Ubuntu': {
 
       # Are we running one of the virtual kernels?
-      $virtual = $::kernelrelease ? {
-        /virtual$/ => '-virtual',
-        default   => versioncmp(String($::operatingsystemrelease), '16.04') >= 0 ? {
-          true    => '-generic',
-          default => '',
-        },
+      if $::kernelrelease =~ /virtual$/ {
+        $suffix = '-virtual'
+      } elsif versioncmp("${::operatingsystemrelease}", '16.04') >= 0 {
+        $suffix = '-generic'
+      } else {
+        $suffix = ''
       }
 
       # List of packages to install

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -8,7 +8,7 @@ class hyperv::debian {
       # Are we running one of the virtual kernels?
       $virtual = $::kernelrelease ? {
         /virtual$/ => '-virtual',
-        default   => versioncmp($::operatingsystemrelease, '16.04') >= 0 ? {
+        default   => versioncmp(String($::operatingsystemrelease), '16.04') >= 0 ? {
           true    => '-generic',
           default => '',
         },

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -15,7 +15,7 @@ class hyperv::debian {
       }
 
       # List of packages to install
-      $packagelist = ["linux-tools${virtual}", "linux-cloud-tools${virtual}"]
+      $packagelist = ["linux-tools${suffix}", "linux-cloud-tools${suffix}"]
 
       if $::operatingsystemrelease  == '14.04' {
         concat($packagelist, 'hv-kvp-daemon-init')


### PR DESCRIPTION
On Ubuntu 16.04 the packages for the non-virtual kernel images now have the suffix -generic, so that's added here.

Also changed to use a "suffix" variable as "virtual" is a fact already, and re-jigged the assignment as nesting it more was making it harder to read.